### PR TITLE
Passport authoring API + consumer UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@ This repo contains the CW1 vertical slice for the Digital Product Passport Build
 4) Start backend
 5) Open the app
 
+## API Demo (Module B)
+1) Copy `.env.example` to `.env` and set DB credentials.
+2) Run migration: `mysql -u <user> -p < db/migrations/001_init.sql`
+3) Run seed: `mysql -u <user> -p comm2020_dpp < db/seed/seed.sql`
+4) Start backend: `mvn -q -DskipTests package && java -cp target/comm2020-dpp-cw1-0.1.0.jar uk.ac.comm2020.App`
+
+Example curls:
+```
+curl "http://localhost:8080/api/templates?category=Battery"
+curl "http://localhost:8080/api/products?category=Battery"
+curl -X POST "http://localhost:8080/api/passports" -H "Content-Type: application/json" -d "{ \"productId\": 1, \"templateId\": 1 }"
+curl -X PUT "http://localhost:8080/api/passports/1" -H "Content-Type: application/json" -d "{ \"fields\": { \"name\": \"EcoCell A1\", \"brand\": \"EcoBrand\", \"origin\": \"UK\", \"chemistry\": \"Li-ion\" } }"
+curl "http://localhost:8080/api/passports/1"
+```
+
+## Module B UI Demo
+- Authoring page: `http://localhost:8080/authoring.html`
+- Consumer page: `http://localhost:8080/consumer.html?id=1`
+- Flow: load category -> create passport -> fill fields -> save -> open consumer view with the new passportId
+
 ## Contracts
 - API contract: `docs/api-contract.md`
 - Data dictionary: `docs/data-dictionary.md`

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,16 @@
       <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.13.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>9.5.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/uk/ac/comm2020/App.java
+++ b/src/main/java/uk/ac/comm2020/App.java
@@ -1,36 +1,61 @@
 package uk.ac.comm2020;
 
-import uk.ac.comm2020.model.Role;
-import uk.ac.comm2020.model.User;
-import uk.ac.comm2020.service.AuthService;
+import com.sun.net.httpserver.HttpServer;
+import uk.ac.comm2020.api.PassportsHandler;
+import uk.ac.comm2020.api.ProductsHandler;
+import uk.ac.comm2020.api.StaticFileHandler;
+import uk.ac.comm2020.api.TemplateByIdHandler;
+import uk.ac.comm2020.api.TemplatesHandler;
+import uk.ac.comm2020.config.EnvConfig;
+import uk.ac.comm2020.dao.PassportDao;
+import uk.ac.comm2020.dao.ProductDao;
+import uk.ac.comm2020.dao.TemplateDao;
+import uk.ac.comm2020.db.Database;
+import uk.ac.comm2020.service.PassportService;
+import uk.ac.comm2020.service.ProductService;
+import uk.ac.comm2020.service.TemplateService;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.Executors;
+
+// Build services, set routes, then start server.
 public class App {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
+        // load env config first
+        EnvConfig config = EnvConfig.load();
+        int port = config.getInt("APP_PORT", 8080);
 
-        AuthService authService = new AuthService();
+        // make db + services
+        Database database = new Database(config);
+        TemplateService templateService = new TemplateService(new TemplateDao(database));
+        ProductService productService = new ProductService(new ProductDao(database));
 
-        User player = new User("alice", Role.PLAYER);
-        User gameKeeper = new User("bob", Role.GAME_KEEPER);
+        // passport need more dao, so build it here
+        PassportService passportService = new PassportService(
+                new PassportDao(database),
+                new TemplateDao(database),
+                new ProductDao(database)
+        );
 
-        // Login as Player
-        authService.login(player);
+        // make http server
+        HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
 
-        try {
-            authService.requireGameKeeper();
-            System.out.println("Player is allowed to perform GameKeeper action");
-        } catch (Exception e) {
-            System.out.println("Player denied: " + e.getMessage());
-        }
+        // api routes
+        server.createContext("/api/templates", new TemplatesHandler(templateService));
+        server.createContext("/api/templates/", new TemplateByIdHandler(templateService));
+        server.createContext("/api/products", new ProductsHandler(productService));
+        server.createContext("/api/passports", new PassportsHandler(passportService));
 
-        // Login as GameKeeper
-        authService.login(gameKeeper);
+        // static files (web page)
+        server.createContext("/", new StaticFileHandler("static"));
 
-        try {
-            authService.requireGameKeeper();
-            System.out.println("GameKeeper allowed to perform action");
-        } catch (Exception e) {
-            System.out.println("GameKeeper denied: " + e.getMessage());
-        }
+        // simple thread pool for requests
+        server.setExecutor(Executors.newFixedThreadPool(10));
+        server.start();
+
+        // log for user
+        System.out.println("API server running on port " + port);
     }
 }

--- a/src/main/java/uk/ac/comm2020/api/PassportsHandler.java
+++ b/src/main/java/uk/ac/comm2020/api/PassportsHandler.java
@@ -1,0 +1,205 @@
+package uk.ac.comm2020.api;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import uk.ac.comm2020.model.Passport;
+import uk.ac.comm2020.service.PassportService;
+import uk.ac.comm2020.service.ServiceException;
+import uk.ac.comm2020.util.JsonUtil;
+import uk.ac.comm2020.util.RequestUtil;
+import uk.ac.comm2020.util.ResponseUtil;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Do routing + basic check here. Real logic stay in service.
+public class PassportsHandler implements HttpHandler {
+    // base path for this api
+    private static final String BASE_PATH = "/api/passports";
+
+    private final PassportService passportService;
+
+    // take service from outside, easy for test and reuse
+    public PassportsHandler(PassportService passportService) {
+        this.passportService = passportService;
+    }
+
+    // Main entry. Look at path, then dispatch.
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String path = exchange.getRequestURI().getPath();
+        try {
+            if (path.equals(BASE_PATH) || path.equals(BASE_PATH + "/")) {
+                handleCollection(exchange);
+                return;
+            }
+
+            if (path.startsWith(BASE_PATH + "/")) {
+                handleItem(exchange, path.substring(BASE_PATH.length() + 1));
+                return;
+            }
+
+            // path not match, just 404
+            ResponseUtil.sendJson(exchange, 404,
+                    ResponseUtil.error("NOT_FOUND", "Endpoint not found", null));
+        } catch (ServiceException e) {
+            // service already know how to explain the error
+            ResponseUtil.sendJson(exchange, e.getStatus(),
+                    ResponseUtil.error(e.getCode(), e.getMessage(), e.getDetails()));
+        } catch (Exception e) {
+            // anything else, treat as server problem
+            ResponseUtil.sendJson(exchange, 500,
+                    ResponseUtil.error("INTERNAL_ERROR", "Unexpected server error", null));
+        }
+    }
+
+    // create draft with productId + templateId
+    private void handleCollection(HttpExchange exchange) throws IOException {
+        // Only POST here, other method no meaning
+        if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+            ResponseUtil.sendJson(exchange, 405,
+                    ResponseUtil.error("METHOD_NOT_ALLOWED", "Only POST is allowed", null));
+            return;
+        }
+
+        // read json body, if broken will throw 400
+        JsonObject json = parseJsonBody(exchange);
+
+        // check required params
+        JsonElement productElement = json.get("productId");
+        JsonElement templateElement = json.get("templateId");
+        if (productElement == null || templateElement == null) {
+            ResponseUtil.sendJson(exchange, 400,
+                    ResponseUtil.error("BAD_REQUEST", "productId and templateId are required", null));
+            return;
+        }
+
+        // parse as number, if not number then reject
+        Long productId = parseLong(productElement);
+        Long templateId = parseLong(templateElement);
+        if (productId == null || templateId == null) {
+            ResponseUtil.sendJson(exchange, 400,
+                    ResponseUtil.error("BAD_REQUEST", "productId and templateId must be numbers", null));
+            return;
+        }
+
+        // get user id from header, missing then use default
+        long createdBy = resolveUserId(exchange);
+
+        // create draft passport
+        Passport passport = passportService.createDraft(productId, templateId, createdBy);
+
+        // return small response, just id + status
+        Map<String, Object> data = new HashMap<>();
+        data.put("passportId", passport.getPassportId());
+        data.put("status", passport.getStatus());
+        ResponseUtil.sendJson(exchange, 200, ResponseUtil.success(data));
+    }
+
+    // project endpoint
+    private void handleItem(HttpExchange exchange, String idPart) throws IOException {
+        long passportId;
+        try {
+            passportId = Long.parseLong(idPart);
+        } catch (NumberFormatException e) {
+            // id is not number, no need continue
+            ResponseUtil.sendJson(exchange, 400,
+                    ResponseUtil.error("BAD_REQUEST", "passportId must be a number", null));
+            return;
+        }
+
+        // method routing
+        if ("GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+            handleGet(exchange, passportId);
+            return;
+        }
+        if ("PUT".equalsIgnoreCase(exchange.getRequestMethod())) {
+            handlePut(exchange, passportId);
+            return;
+        }
+
+        ResponseUtil.sendJson(exchange, 405,
+                ResponseUtil.error("METHOD_NOT_ALLOWED", "Only GET or PUT is allowed", null));
+    }
+
+    private void handlePut(HttpExchange exchange, long passportId) throws IOException {
+        JsonObject json = parseJsonBody(exchange);
+
+        // fields must be object, otherwise service cannot update
+        JsonElement fieldsElement = json.get("fields");
+        if (fieldsElement == null || !fieldsElement.isJsonObject()) {
+            ResponseUtil.sendJson(exchange, 400,
+                    ResponseUtil.error("BAD_REQUEST", "fields object is required", null));
+            return;
+        }
+
+        JsonObject fields = fieldsElement.getAsJsonObject();
+
+        // update only fields, other things not touch here
+        Passport updated = passportService.updateFields(passportId, fields);
+
+        // keep response short
+        Map<String, Object> data = new HashMap<>();
+        data.put("passportId", updated.getPassportId());
+        data.put("status", updated.getStatus());
+        ResponseUtil.sendJson(exchange, 200, ResponseUtil.success(data));
+    }
+
+    // return all info, include scores and fields
+    private void handleGet(HttpExchange exchange, long passportId) throws IOException {
+        Passport passport = passportService.getPassport(passportId);
+
+        // map to response json
+        Map<String, Object> data = new HashMap<>();
+        data.put("passportId", passport.getPassportId());
+        data.put("productId", passport.getProductId());
+        data.put("templateId", passport.getTemplateId());
+        data.put("status", passport.getStatus());
+        data.put("fields", passport.getFields());
+        data.put("completenessScore", passport.getCompletenessScore());
+        data.put("confidenceScore", passport.getConfidenceScore());
+        ResponseUtil.sendJson(exchange, 200, ResponseUtil.success(data));
+    }
+
+    // Read X-User-Id from header.
+    // If missing or invalid, fallback to 1.
+    private long resolveUserId(HttpExchange exchange) {
+        String header = exchange.getRequestHeaders().getFirst("X-User-Id");
+        if (header == null || header.isBlank()) {
+            return 1L;
+        }
+        try {
+            long id = Long.parseLong(header.trim());
+            return id > 0 ? id : 1L;
+        } catch (NumberFormatException e) {
+            return 1L;
+        }
+    }
+
+    // Safe parse long from json element.
+    // If not a number, just return null.
+    private Long parseLong(JsonElement element) {
+        if (element == null || !element.isJsonPrimitive()) {
+            return null;
+        }
+        try {
+            return element.getAsLong();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // Read request body and parse json.
+    // throw ServiceException, then become 400.
+    private JsonObject parseJsonBody(HttpExchange exchange) throws IOException {
+        String body = RequestUtil.readBody(exchange);
+        try {
+            return JsonUtil.parseObject(body);
+        } catch (Exception e) {
+            throw new ServiceException("BAD_REQUEST", "Invalid JSON body", 400, null, e);
+        }
+    }
+}

--- a/src/main/java/uk/ac/comm2020/api/ProductsHandler.java
+++ b/src/main/java/uk/ac/comm2020/api/ProductsHandler.java
@@ -1,0 +1,64 @@
+package uk.ac.comm2020.api;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import uk.ac.comm2020.model.Product;
+import uk.ac.comm2020.service.ProductService;
+import uk.ac.comm2020.service.ServiceException;
+import uk.ac.comm2020.util.RequestUtil;
+import uk.ac.comm2020.util.ResponseUtil;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+// Handler for products api.
+// Only do simple check here, then call service.
+public class ProductsHandler implements HttpHandler {
+    private final ProductService productService;
+
+    // take service from outside, so code easy to use and test
+    public ProductsHandler(ProductService productService) {
+        this.productService = productService;
+    }
+
+    // Main entry. Only support GET.
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        try {
+            // only GET is ok here
+            if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                ResponseUtil.sendJson(exchange, 405,
+                        ResponseUtil.error("METHOD_NOT_ALLOWED", "Only GET is allowed", null));
+                return;
+            }
+
+            Map<String, String> query = RequestUtil.parseQuery(exchange.getRequestURI());
+
+            // category is must, without it we cannot find data
+            String category = query.get("category");
+            if (category == null || category.isBlank()) {
+                ResponseUtil.sendJson(exchange, 400,
+                        ResponseUtil.error("BAD_REQUEST", "Query param 'category' is required", null));
+                return;
+            }
+
+            // get products list by category
+            List<Product> products = productService.getProductsByCategory(category);
+
+            // wrap data then send back
+            Map<String, Object> data = new HashMap<>();
+            data.put("products", products);
+            ResponseUtil.sendJson(exchange, 200, ResponseUtil.success(data));
+        } catch (ServiceException e) {
+            // service error, keep status and message
+            ResponseUtil.sendJson(exchange, e.getStatus(),
+                    ResponseUtil.error(e.getCode(), e.getMessage(), e.getDetails()));
+        } catch (Exception e) {
+            // other error, just 500
+            ResponseUtil.sendJson(exchange, 500,
+                    ResponseUtil.error("INTERNAL_ERROR", "Unexpected server error", null));
+        }
+    }
+}

--- a/src/main/java/uk/ac/comm2020/api/StaticFileHandler.java
+++ b/src/main/java/uk/ac/comm2020/api/StaticFileHandler.java
@@ -1,0 +1,99 @@
+package uk.ac.comm2020.api;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+// Simple static file handler.
+// Read file from classpath, then send it to browser.
+public class StaticFileHandler implements HttpHandler {
+    private final String basePath;
+    private final Map<String, String> contentTypes;
+
+    // basePath is folder in resources (like "static")
+    public StaticFileHandler(String basePath) {
+        // make sure no leading "/", so classloader can find it
+        this.basePath = basePath.startsWith("/") ? basePath.substring(1) : basePath;
+        this.contentTypes = defaultContentTypes();
+    }
+
+    // Only handle GET, other method just block.
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+
+        // get path from url
+        URI uri = exchange.getRequestURI();
+        String path = uri.getPath();
+
+        // if user visit "/", send them to home page
+        if (path == null || path.isBlank() || "/".equals(path)) {
+            redirect(exchange, "/authoring.html");
+            return;
+        }
+
+        // build classpath resource path
+        String resourcePath = basePath + (path.startsWith("/") ? path : "/" + path);
+
+        // read file as stream, then send bytes out
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+            if (stream == null) {
+                // file not found
+                exchange.sendResponseHeaders(404, -1);
+                return;
+            }
+
+            byte[] bytes = stream.readAllBytes();
+
+            // set content type by file ext
+            exchange.getResponseHeaders().set("Content-Type", contentTypeFor(path));
+
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+        } finally {
+            // always close exchange
+            exchange.close();
+        }
+    }
+
+    // send 302 redirect
+    private void redirect(HttpExchange exchange, String location) throws IOException {
+        exchange.getResponseHeaders().set("Location", location);
+        exchange.sendResponseHeaders(302, -1);
+        exchange.close();
+    }
+
+    // pick content type by suffix, if not match then use default
+    private String contentTypeFor(String path) {
+        String lower = path.toLowerCase();
+        for (Map.Entry<String, String> entry : contentTypes.entrySet()) {
+            if (lower.endsWith(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return "application/octet-stream";
+    }
+
+    // basic content types for common files
+    private Map<String, String> defaultContentTypes() {
+        Map<String, String> map = new HashMap<>();
+        map.put(".html", "text/html; charset=" + StandardCharsets.UTF_8);
+        map.put(".css", "text/css; charset=" + StandardCharsets.UTF_8);
+        map.put(".js", "application/javascript; charset=" + StandardCharsets.UTF_8);
+        map.put(".json", "application/json; charset=" + StandardCharsets.UTF_8);
+        map.put(".png", "image/png");
+        map.put(".jpg", "image/jpeg");
+        map.put(".jpeg", "image/jpeg");
+        map.put(".svg", "image/svg+xml");
+        return map;
+    }
+}

--- a/src/main/java/uk/ac/comm2020/api/TemplateByIdHandler.java
+++ b/src/main/java/uk/ac/comm2020/api/TemplateByIdHandler.java
@@ -1,0 +1,71 @@
+package uk.ac.comm2020.api;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import uk.ac.comm2020.model.Template;
+import uk.ac.comm2020.service.ServiceException;
+import uk.ac.comm2020.service.TemplateService;
+import uk.ac.comm2020.util.ResponseUtil;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Handler for GET /api/templates/{id}.
+// Get one template by id, then return json.
+public class TemplateByIdHandler implements HttpHandler {
+    private final TemplateService templateService;
+
+    // take service from outside, so easy to use and test
+    public TemplateByIdHandler(TemplateService templateService) {
+        this.templateService = templateService;
+    }
+
+    // Only handle GET. Other method not needed here.
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        try {
+            // only GET is ok
+            if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                ResponseUtil.sendJson(exchange, 405,
+                        ResponseUtil.error("METHOD_NOT_ALLOWED", "Only GET is allowed", null));
+                return;
+            }
+
+            // get id from path
+            String path = exchange.getRequestURI().getPath();
+            String idPart = path.substring("/api/templates/".length());
+
+            long templateId;
+            try {
+                templateId = Long.parseLong(idPart);
+            } catch (NumberFormatException e) {
+                // id not a number return 400
+                ResponseUtil.sendJson(exchange, 400,
+                        ResponseUtil.error("BAD_REQUEST", "templateId must be a number", null));
+                return;
+            }
+
+            // ask service for template
+            Template template = templateService.getTemplateById(templateId);
+
+            // make response data
+            Map<String, Object> data = new HashMap<>();
+            data.put("templateId", template.getTemplateId());
+            data.put("category", template.getCategory());
+            data.put("requiredFields", template.getRequiredFields());
+            data.put("optionalFields", template.getOptionalFields());
+            data.put("ruleSetId", template.getRuleSetId());
+
+            ResponseUtil.sendJson(exchange, 200, ResponseUtil.success(data));
+        } catch (ServiceException e) {
+            // service error, keep status/code/message
+            ResponseUtil.sendJson(exchange, e.getStatus(),
+                    ResponseUtil.error(e.getCode(), e.getMessage(), e.getDetails()));
+        } catch (Exception e) {
+            // other error return 500
+            ResponseUtil.sendJson(exchange, 500,
+                    ResponseUtil.error("INTERNAL_ERROR", "Unexpected server error", null));
+        }
+    }
+}

--- a/src/main/java/uk/ac/comm2020/api/TemplatesHandler.java
+++ b/src/main/java/uk/ac/comm2020/api/TemplatesHandler.java
@@ -1,0 +1,63 @@
+package uk.ac.comm2020.api;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import uk.ac.comm2020.model.Template;
+import uk.ac.comm2020.service.ServiceException;
+import uk.ac.comm2020.service.TemplateService;
+import uk.ac.comm2020.util.RequestUtil;
+import uk.ac.comm2020.util.ResponseUtil;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+// Handler for templates list api.
+// Use category in query, then return templates list.
+public class TemplatesHandler implements HttpHandler {
+    private final TemplateService templateService;
+
+    // take service from outside, easy to test
+    public TemplatesHandler(TemplateService templateService) {
+        this.templateService = templateService;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        try {
+            if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                ResponseUtil.sendJson(exchange, 405,
+                        ResponseUtil.error("METHOD_NOT_ALLOWED", "Only GET is allowed", null));
+                return;
+            }
+
+            // read query from url
+            Map<String, String> query = RequestUtil.parseQuery(exchange.getRequestURI());
+
+            // category is must, no category then no data
+            String category = query.get("category");
+            if (category == null || category.isBlank()) {
+                ResponseUtil.sendJson(exchange, 400,
+                        ResponseUtil.error("BAD_REQUEST", "Query param 'category' is required", null));
+                return;
+            }
+
+            // get list from service
+            List<Template> templates = templateService.getTemplatesByCategory(category);
+
+            // wrap and send back
+            Map<String, Object> data = new HashMap<>();
+            data.put("templates", templates);
+            ResponseUtil.sendJson(exchange, 200, ResponseUtil.success(data));
+        } catch (ServiceException e) {
+            // service error, keep status and msg
+            ResponseUtil.sendJson(exchange, e.getStatus(),
+                    ResponseUtil.error(e.getCode(), e.getMessage(), e.getDetails()));
+        } catch (Exception e) {
+            // other error return 500
+            ResponseUtil.sendJson(exchange, 500,
+                    ResponseUtil.error("INTERNAL_ERROR", "Unexpected server error", null));
+        }
+    }
+}

--- a/src/main/java/uk/ac/comm2020/config/EnvConfig.java
+++ b/src/main/java/uk/ac/comm2020/config/EnvConfig.java
@@ -1,0 +1,93 @@
+package uk.ac.comm2020.config;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+// Simple env config loader.
+// Read from system env first, then try .env file.
+public class EnvConfig {
+    private final Map<String, String> values;
+
+    private EnvConfig(Map<String, String> values) {
+        this.values = values;
+    }
+
+    // Load config values.
+    // If .env exists, it can fill missing keys.
+    public static EnvConfig load() {
+        // start from real env vars
+        Map<String, String> values = new HashMap<>(System.getenv());
+
+        // try read local .env file
+        Path envPath = Paths.get(".env");
+        if (Files.exists(envPath)) {
+            try {
+                List<String> lines = Files.readAllLines(envPath, StandardCharsets.UTF_8);
+
+                for (String line : lines) {
+                    String trimmed = line.trim();
+
+                    // skip empty line and comment line
+                    if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                        continue;
+                    }
+
+                    // we only accept "key=value"
+                    int idx = trimmed.indexOf('=');
+                    if (idx <= 0) {
+                        continue;
+                    }
+
+                    String key = trimmed.substring(0, idx).trim();
+                    String value = trimmed.substring(idx + 1).trim();
+
+                    // remove quotes like "abc"
+                    if (value.startsWith("\"") && value.endsWith("\"") && value.length() >= 2) {
+                        value = value.substring(1, value.length() - 1);
+                    }
+
+                    // only set when env not already has it
+                    if (!values.containsKey(key) || values.get(key) == null || values.get(key).isBlank()) {
+                        values.put(key, value);
+                    }
+                }
+            } catch (IOException ignored) {
+            }
+        }
+
+        return new EnvConfig(values);
+    }
+
+    // Get value with default.
+    public String get(String key, String defaultValue) {
+        return values.getOrDefault(key, defaultValue);
+    }
+
+    // Get value, must exist.
+    public String require(String key) {
+        String value = values.get(key);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Missing required env var: " + key);
+        }
+        return value;
+    }
+
+    // Get int value, parse fail then use default.
+    public int getInt(String key, int defaultValue) {
+        String value = values.get(key);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+}

--- a/src/main/java/uk/ac/comm2020/dao/PassportDao.java
+++ b/src/main/java/uk/ac/comm2020/dao/PassportDao.java
@@ -1,0 +1,119 @@
+package uk.ac.comm2020.dao;
+
+import uk.ac.comm2020.db.Database;
+import uk.ac.comm2020.model.Passport;
+import uk.ac.comm2020.util.JsonUtil;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Optional;
+
+// DAO for passport table.
+// Only do DB read/write here, no business rule.
+public class PassportDao {
+    private final Database database;
+
+    // keep db helper here
+    public PassportDao(Database database) {
+        this.database = database;
+    }
+
+    // Make a new draft passport row.
+    // fields start as {}, scores start as 0, status is DRAFT.
+    public Passport createDraft(long productId, long templateId, long createdBy) throws SQLException {
+        String sql = "INSERT INTO passport (product_id, template_id, fields, completeness_score, confidence_score, status, created_by) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?)";
+        try (Connection connection = database.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+
+            statement.setLong(1, productId);
+            statement.setLong(2, templateId);
+            statement.setString(3, "{}");
+
+            // keep 4 decimals, so score look stable
+            statement.setBigDecimal(4, BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP));
+            statement.setBigDecimal(5, BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP));
+
+            statement.setString(6, "DRAFT");
+            statement.setLong(7, createdBy);
+
+            int affected = statement.executeUpdate();
+            if (affected > 0) {
+                // normal way: read auto id from driver
+                try (ResultSet keys = statement.getGeneratedKeys()) {
+                    if (keys.next()) {
+                        long passportId = keys.getLong(1);
+                        return new Passport(passportId, productId, templateId, "DRAFT", JsonUtil.parseObject("{}"), 0.0, 0.0);
+                    }
+                }
+
+                // fallback way: some db/driver may not return keys well
+                try (PreparedStatement fallback = connection.prepareStatement("SELECT LAST_INSERT_ID()");
+                     ResultSet rs = fallback.executeQuery()) {
+                    if (rs.next()) {
+                        long passportId = rs.getLong(1);
+                        if (passportId > 0) {
+                            return new Passport(passportId, productId, templateId, "DRAFT", JsonUtil.parseObject("{}"), 0.0, 0.0);
+                        }
+                    }
+                }
+            }
+        }
+
+        throw new SQLException("Failed to create passport");
+    }
+
+    // Find passport by id. If not found, return empty.
+    public Optional<Passport> findById(long passportId) throws SQLException {
+        String sql = "SELECT passport_id, product_id, template_id, status, fields, completeness_score, confidence_score " +
+                "FROM passport WHERE passport_id = ?";
+        try (Connection connection = database.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setLong(1, passportId);
+
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapPassport(rs));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    // Update fields json and scores for one passport.
+    public void updateFields(long passportId, String fieldsJson, double completenessScore, double confidenceScore) throws SQLException {
+        String sql = "UPDATE passport SET fields = ?, completeness_score = ?, confidence_score = ? WHERE passport_id = ?";
+        try (Connection connection = database.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setString(1, fieldsJson);
+
+            // store with 4 decimals, same as insert
+            statement.setBigDecimal(2, BigDecimal.valueOf(completenessScore).setScale(4, RoundingMode.HALF_UP));
+            statement.setBigDecimal(3, BigDecimal.valueOf(confidenceScore).setScale(4, RoundingMode.HALF_UP));
+
+            statement.setLong(4, passportId);
+
+            statement.executeUpdate();
+        }
+    }
+
+    // Map one DB row -> Passport object.
+    private Passport mapPassport(ResultSet rs) throws SQLException {
+        return new Passport(
+                rs.getLong("passport_id"),
+                rs.getLong("product_id"),
+                rs.getLong("template_id"),
+                rs.getString("status"),
+                JsonUtil.parseObject(rs.getString("fields")),
+                rs.getDouble("completeness_score"),
+                rs.getDouble("confidence_score")
+        );
+    }
+}

--- a/src/main/java/uk/ac/comm2020/dao/ProductDao.java
+++ b/src/main/java/uk/ac/comm2020/dao/ProductDao.java
@@ -1,0 +1,72 @@
+package uk.ac.comm2020.dao;
+
+import uk.ac.comm2020.db.Database;
+import uk.ac.comm2020.model.Product;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+// DAO for product table.
+// Do DB query here, keep it simple.
+public class ProductDao {
+    private final Database database;
+
+    // keep db helper here
+    public ProductDao(Database database) {
+        this.database = database;
+    }
+
+    // Find all products in one category.
+    public List<Product> findByCategory(String category) throws SQLException {
+        String sql = "SELECT product_id, name, category, brand, description, passport_version " +
+                "FROM product WHERE category = ?";
+        List<Product> products = new ArrayList<>();
+
+        try (Connection connection = database.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setString(1, category);
+
+            // read list from DB
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    products.add(mapProduct(rs));
+                }
+            }
+        }
+
+        return products;
+    }
+
+    // Check product id exist or not.
+    public boolean exists(long productId) throws SQLException {
+        String sql = "SELECT 1 FROM product WHERE product_id = ?";
+
+        try (Connection connection = database.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setLong(1, productId);
+
+            // if any row, then it exists
+            try (ResultSet rs = statement.executeQuery()) {
+                return rs.next();
+            }
+        }
+    }
+
+    // Map one DB row -> Product object.
+    private Product mapProduct(ResultSet rs) throws SQLException {
+        return new Product(
+                rs.getLong("product_id"),
+                rs.getString("name"),
+                rs.getString("category"),
+                rs.getString("brand"),
+                rs.getString("description"),
+                rs.getInt("passport_version")
+        );
+    }
+}

--- a/src/main/java/uk/ac/comm2020/dao/TemplateDao.java
+++ b/src/main/java/uk/ac/comm2020/dao/TemplateDao.java
@@ -1,0 +1,120 @@
+package uk.ac.comm2020.dao;
+
+import uk.ac.comm2020.db.Database;
+import uk.ac.comm2020.model.Template;
+import uk.ac.comm2020.util.JsonUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+// DAO for template table.
+// Just do DB stuff here, no extra logic.
+public class TemplateDao {
+    private final Database database;
+
+    // keep db helper here
+    public TemplateDao(Database database) {
+        this.database = database;
+    }
+
+    // Find templates by category.
+    public List<Template> findByCategory(String category) throws SQLException {
+        String sql = "SELECT template_id, category, required_fields, optional_fields, rule_set_id " +
+                "FROM template WHERE category = ?";
+        List<Template> templates = new ArrayList<>();
+
+        try (Connection connection = database.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setString(1, category);
+
+            // read list from DB
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    templates.add(mapTemplate(rs));
+                }
+            }
+        }
+
+        return templates;
+    }
+
+    // Get required fields list by template id.
+    // Return empty if not found.
+    public Optional<List<String>> findRequiredFieldsById(long templateId) throws SQLException {
+        String sql = "SELECT required_fields FROM template WHERE template_id = ?";
+
+        try (Connection connection = database.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setLong(1, templateId);
+
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    String json = rs.getString("required_fields");
+                    return Optional.of(JsonUtil.parseStringList(json));
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    // Find one template by id.
+    public Optional<Template> findById(long templateId) throws SQLException {
+        String sql = "SELECT template_id, category, required_fields, optional_fields, rule_set_id " +
+                "FROM template WHERE template_id = ?";
+
+        try (Connection connection = database.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setLong(1, templateId);
+
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapTemplate(rs));
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    // Check template id exist or not.
+    public boolean exists(long templateId) throws SQLException {
+        String sql = "SELECT 1 FROM template WHERE template_id = ?";
+
+        try (Connection connection = database.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setLong(1, templateId);
+
+            // if any row, then it exists
+            try (ResultSet rs = statement.executeQuery()) {
+                return rs.next();
+            }
+        }
+    }
+
+    // Map one DB row -> Template object.
+    private Template mapTemplate(ResultSet rs) throws SQLException {
+        long templateId = rs.getLong("template_id");
+        String category = rs.getString("category");
+        String required = rs.getString("required_fields");
+        String optional = rs.getString("optional_fields");
+        int ruleSetId = rs.getInt("rule_set_id");
+
+        return new Template(
+                templateId,
+                category,
+                JsonUtil.parseStringList(required),
+                JsonUtil.parseStringList(optional),
+                ruleSetId
+        );
+    }
+}

--- a/src/main/java/uk/ac/comm2020/db/Database.java
+++ b/src/main/java/uk/ac/comm2020/db/Database.java
@@ -1,0 +1,44 @@
+package uk.ac.comm2020.db;
+
+import uk.ac.comm2020.config.EnvConfig;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+// DB helper. Make JDBC connection from env config.
+public class Database {
+    private final EnvConfig config;
+
+    // keep config, and load mysql driver once
+    public Database(EnvConfig config) {
+        this.config = config;
+        try {
+            Class.forName("com.mysql.cj.jdbc.Driver");
+        } catch (ClassNotFoundException e) {
+            // without driver, nothing can work
+            throw new IllegalStateException("MySQL driver not found", e);
+        }
+    }
+
+    // Get a new DB connection.
+    public Connection getConnection() throws SQLException {
+        // read db info from env, if missing then use default
+        String host = config.get("DB_HOST", "localhost");
+        String port = config.get("DB_PORT", "3306");
+        String name = config.get("DB_NAME", "comm2020_dpp");
+        String user = config.get("DB_USER", "comm2020");
+        String password = config.get("DB_PASSWORD", "comm2020_password");
+
+        // build jdbc url
+        String url = String.format(
+                "jdbc:mysql://%s:%s/%s?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC",
+                host,
+                port,
+                name
+        );
+
+        // open connection and return it
+        return DriverManager.getConnection(url, user, password);
+    }
+}

--- a/src/main/java/uk/ac/comm2020/model/Passport.java
+++ b/src/main/java/uk/ac/comm2020/model/Passport.java
@@ -1,0 +1,66 @@
+package uk.ac.comm2020.model;
+
+import com.google.gson.JsonObject;
+
+// Passport model.
+public class Passport {
+    private final long passportId;
+    private final long productId;
+    private final long templateId;
+    private final String status;
+    private final JsonObject fields;
+    private final double completenessScore;
+    private final double confidenceScore;
+
+    // Build one passport object.
+    public Passport(long passportId,
+                    long productId,
+                    long templateId,
+                    String status,
+                    JsonObject fields,
+                    double completenessScore,
+                    double confidenceScore) {
+        this.passportId = passportId;
+        this.productId = productId;
+        this.templateId = templateId;
+        this.status = status;
+        this.fields = fields;
+        this.completenessScore = completenessScore;
+        this.confidenceScore = confidenceScore;
+    }
+
+    // id of passport row
+    public long getPassportId() {
+        return passportId;
+    }
+
+    // which product it links to
+    public long getProductId() {
+        return productId;
+    }
+
+    // which template it uses
+    public long getTemplateId() {
+        return templateId;
+    }
+
+    // status like DRAFT / DONE (depends on your code)
+    public String getStatus() {
+        return status;
+    }
+
+    // all fields data in json
+    public JsonObject getFields() {
+        return fields;
+    }
+
+    // score for how full it is
+    public double getCompletenessScore() {
+        return completenessScore;
+    }
+
+    // score for how sure it is
+    public double getConfidenceScore() {
+        return confidenceScore;
+    }
+}

--- a/src/main/java/uk/ac/comm2020/model/Product.java
+++ b/src/main/java/uk/ac/comm2020/model/Product.java
@@ -1,0 +1,51 @@
+package uk.ac.comm2020.model;
+
+// Product model.
+public class Product {
+    private final long productId;
+    private final String name;
+    private final String category;
+    private final String brand;
+    private final String description;
+    private final int passportVersion;
+
+    // Build one product object.
+    public Product(long productId, String name, String category, String brand, String description, int passportVersion) {
+        this.productId = productId;
+        this.name = name;
+        this.category = category;
+        this.brand = brand;
+        this.description = description;
+        this.passportVersion = passportVersion;
+    }
+
+    // product id in DB
+    public long getProductId() {
+        return productId;
+    }
+
+    // product name
+    public String getName() {
+        return name;
+    }
+
+    // product category
+    public String getCategory() {
+        return category;
+    }
+
+    // product brand
+    public String getBrand() {
+        return brand;
+    }
+
+    // simple text about product
+    public String getDescription() {
+        return description;
+    }
+
+    // version for passport data (for upgrade maybe)
+    public int getPassportVersion() {
+        return passportVersion;
+    }
+}

--- a/src/main/java/uk/ac/comm2020/model/Template.java
+++ b/src/main/java/uk/ac/comm2020/model/Template.java
@@ -1,0 +1,46 @@
+package uk.ac.comm2020.model;
+
+import java.util.List;
+
+// Template model.
+public class Template {
+    private final long templateId;
+    private final String category;
+    private final List<String> requiredFields;
+    private final List<String> optionalFields;
+    private final int ruleSetId;
+
+    // Build one template object.
+    public Template(long templateId, String category, List<String> requiredFields, List<String> optionalFields, int ruleSetId) {
+        this.templateId = templateId;
+        this.category = category;
+        this.requiredFields = requiredFields;
+        this.optionalFields = optionalFields;
+        this.ruleSetId = ruleSetId;
+    }
+
+    // template id in DB
+    public long getTemplateId() {
+        return templateId;
+    }
+
+    // category name for this template
+    public String getCategory() {
+        return category;
+    }
+
+    // fields user must fill
+    public List<String> getRequiredFields() {
+        return requiredFields;
+    }
+
+    // fields user can skip if they want
+    public List<String> getOptionalFields() {
+        return optionalFields;
+    }
+
+    // id for rule set (used by rule engine maybe)
+    public int getRuleSetId() {
+        return ruleSetId;
+    }
+}

--- a/src/main/java/uk/ac/comm2020/service/PassportService.java
+++ b/src/main/java/uk/ac/comm2020/service/PassportService.java
@@ -1,0 +1,164 @@
+package uk.ac.comm2020.service;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import uk.ac.comm2020.dao.PassportDao;
+import uk.ac.comm2020.dao.ProductDao;
+import uk.ac.comm2020.dao.TemplateDao;
+import uk.ac.comm2020.model.Passport;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+// Service for passport.
+// Do checks + simple rules here, then call DAO.
+public class PassportService {
+    private final PassportDao passportDao;
+    private final TemplateDao templateDao;
+    private final ProductDao productDao;
+
+    // keep all dao here
+    public PassportService(PassportDao passportDao, TemplateDao templateDao, ProductDao productDao) {
+        this.passportDao = passportDao;
+        this.templateDao = templateDao;
+        this.productDao = productDao;
+    }
+
+    // Make a draft passport.
+    // Check product and template first, so DB insert not waste.
+    public Passport createDraft(long productId, long templateId, long createdBy) {
+        try {
+            // product must exist
+            if (!productDao.exists(productId)) {
+                throw new ServiceException("NOT_FOUND", "Product not found", 404, null, null);
+            }
+
+            // template must exist
+            if (!templateDao.exists(templateId)) {
+                throw new ServiceException("NOT_FOUND", "Template not found", 404, null, null);
+            }
+
+            return passportDao.createDraft(productId, templateId, createdBy);
+        } catch (SQLException e) {
+            // DB problem, wrap it as service error
+            throw new ServiceException("DATABASE_ERROR", "Failed to create passport", 500, null, e);
+        }
+    }
+
+    // Update fields for one passport.
+    // Also check required fields, and update score.
+    public Passport updateFields(long passportId, JsonObject fields) {
+        try {
+            // passport must exist
+            Passport passport = passportDao.findById(passportId)
+                    .orElseThrow(() -> new ServiceException("NOT_FOUND", "Passport not found", 404, null, null));
+
+            // need required fields list from template
+            List<String> requiredFields = templateDao.findRequiredFieldsById(passport.getTemplateId())
+                    .orElseThrow(() -> new ServiceException("NOT_FOUND", "Template not found", 404, null, null));
+
+            // check required fields are filled
+            List<String> missing = validateRequiredFields(requiredFields, fields);
+            if (!missing.isEmpty()) {
+                // tell client which keys are missing
+                ServiceException error = new ServiceException(
+                        "VALIDATION_ERROR",
+                        "Missing required fields",
+                        400,
+                        ServiceException.details("missingFields", missing),
+                        null
+                );
+                throw error;
+            }
+
+            // calc score, then save
+            double completeness = calculateCompleteness(requiredFields, fields);
+
+            // confidence not ready now, so keep 0
+            double confidence = 0.0;
+
+            passportDao.updateFields(passportId, fields.toString(), completeness, confidence);
+
+            // return new object with updated data
+            return new Passport(
+                    passport.getPassportId(),
+                    passport.getProductId(),
+                    passport.getTemplateId(),
+                    passport.getStatus(),
+                    fields,
+                    completeness,
+                    confidence
+            );
+        } catch (SQLException e) {
+            throw new ServiceException("DATABASE_ERROR", "Failed to update passport", 500, null, e);
+        }
+    }
+
+    // Get one passport by id.
+    public Passport getPassport(long passportId) {
+        try {
+            return passportDao.findById(passportId)
+                    .orElseThrow(() -> new ServiceException("NOT_FOUND", "Passport not found", 404, null, null));
+        } catch (SQLException e) {
+            throw new ServiceException("DATABASE_ERROR", "Failed to load passport", 500, null, e);
+        }
+    }
+
+    // Check all required keys, return missing list.
+    private List<String> validateRequiredFields(List<String> requiredFields, JsonObject fields) {
+        List<String> missing = new ArrayList<>();
+        for (String key : requiredFields) {
+            if (!isFilled(fields, key)) {
+                missing.add(key);
+            }
+        }
+        return missing;
+    }
+
+    // Tell if one key is filled or not.
+    // Empty string / empty list / empty object -> treat as not filled.
+    private boolean isFilled(JsonObject fields, String key) {
+        if (fields == null || !fields.has(key)) {
+            return false;
+        }
+
+        JsonElement value = fields.get(key);
+        if (value == null || value.isJsonNull()) {
+            return false;
+        }
+
+        if (value.isJsonPrimitive()) {
+            if (value.getAsJsonPrimitive().isString()) {
+                return !value.getAsString().isBlank();
+            }
+            return true;
+        }
+
+        if (value.isJsonArray()) {
+            return value.getAsJsonArray().size() > 0;
+        }
+
+        if (value.isJsonObject()) {
+            return value.getAsJsonObject().size() > 0;
+        }
+
+        return true;
+    }
+
+    // Simple completeness score: filled / total required.
+    private double calculateCompleteness(List<String> requiredFields, JsonObject fields) {
+        if (requiredFields.isEmpty()) {
+            return 1.0;
+        }
+
+        int filled = 0;
+        for (String key : requiredFields) {
+            if (isFilled(fields, key)) {
+                filled += 1;
+            }
+        }
+
+        return (double) filled / (double) requiredFields.size();
+    }
+}

--- a/src/main/java/uk/ac/comm2020/service/ProductService.java
+++ b/src/main/java/uk/ac/comm2020/service/ProductService.java
@@ -1,0 +1,28 @@
+package uk.ac.comm2020.service;
+
+import uk.ac.comm2020.dao.ProductDao;
+import uk.ac.comm2020.model.Product;
+
+import java.sql.SQLException;
+import java.util.List;
+
+// Service for product.
+// Mostly just call DAO, and wrap DB error.
+public class ProductService {
+    private final ProductDao productDao;
+
+    // keep dao here
+    public ProductService(ProductDao productDao) {
+        this.productDao = productDao;
+    }
+
+    // Get products list by category.
+    public List<Product> getProductsByCategory(String category) {
+        try {
+            return productDao.findByCategory(category);
+        } catch (SQLException e) {
+            // DB fail, return 500
+            throw new ServiceException("DATABASE_ERROR", "Failed to load products", 500, null, e);
+        }
+    }
+}

--- a/src/main/java/uk/ac/comm2020/service/ServiceException.java
+++ b/src/main/java/uk/ac/comm2020/service/ServiceException.java
@@ -1,0 +1,45 @@
+package uk.ac.comm2020.service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+// Custom error for service layer.
+// Keep code + http status + extra info for client.
+public class ServiceException extends RuntimeException {
+    private final String code;
+    private final int status;
+    private final Map<String, Object> details;
+
+    // code is like NOT_FOUND / DATABASE_ERROR, status is http status
+    public ServiceException(String code, String message, int status, Map<String, Object> details, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+        this.status = status;
+
+        // make details read-only, so nobody change it later
+        this.details = details == null ? null : Collections.unmodifiableMap(details);
+    }
+
+    // error code for client
+    public String getCode() {
+        return code;
+    }
+
+    // http status for client
+    public int getStatus() {
+        return status;
+    }
+
+    // extra info, can be null
+    public Map<String, Object> getDetails() {
+        return details;
+    }
+
+    // small helper to make details map fast
+    public static Map<String, Object> details(String key, Object value) {
+        Map<String, Object> details = new HashMap<>();
+        details.put(key, value);
+        return details;
+    }
+}

--- a/src/main/java/uk/ac/comm2020/service/TemplateService.java
+++ b/src/main/java/uk/ac/comm2020/service/TemplateService.java
@@ -1,0 +1,38 @@
+package uk.ac.comm2020.service;
+
+import uk.ac.comm2020.dao.TemplateDao;
+import uk.ac.comm2020.model.Template;
+
+import java.sql.SQLException;
+import java.util.List;
+
+// Service for template.
+// Call DAO, and turn DB error into ServiceException.
+public class TemplateService {
+    private final TemplateDao templateDao;
+
+    // keep dao here
+    public TemplateService(TemplateDao templateDao) {
+        this.templateDao = templateDao;
+    }
+
+    // Get templates list by category.
+    public List<Template> getTemplatesByCategory(String category) {
+        try {
+            return templateDao.findByCategory(category);
+        } catch (SQLException e) {
+            // DB fail return 500
+            throw new ServiceException("DATABASE_ERROR", "Failed to load templates", 500, null, e);
+        }
+    }
+
+    // Get one template by id.
+    public Template getTemplateById(long templateId) {
+        try {
+            return templateDao.findById(templateId)
+                    .orElseThrow(() -> new ServiceException("NOT_FOUND", "Template not found", 404, null, null));
+        } catch (SQLException e) {
+            throw new ServiceException("DATABASE_ERROR", "Failed to load template", 500, null, e);
+        }
+    }
+}

--- a/src/main/java/uk/ac/comm2020/util/JsonUtil.java
+++ b/src/main/java/uk/ac/comm2020/util/JsonUtil.java
@@ -1,0 +1,59 @@
+package uk.ac.comm2020.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// Small json helper.
+// Wrap Gson stuff, so other code look clean.
+public final class JsonUtil {
+    // one Gson instance is enough
+    private static final Gson GSON = new GsonBuilder().serializeNulls().create();
+
+    private JsonUtil() {
+    }
+
+    // get Gson if someone need it
+    public static Gson gson() {
+        return GSON;
+    }
+
+    // turn object -> json string
+    public static String toJson(Object value) {
+        return GSON.toJson(value);
+    }
+
+    // parse json string -> JsonObject
+    // if input empty, return empty object
+    public static JsonObject parseObject(String json) {
+        if (json == null || json.isBlank()) {
+            return new JsonObject();
+        }
+        return JsonParser.parseString(json).getAsJsonObject();
+    }
+
+    // parse json string -> JsonArray
+    // if input empty, return empty array
+    public static JsonArray parseArray(String json) {
+        if (json == null || json.isBlank()) {
+            return new JsonArray();
+        }
+        return JsonParser.parseString(json).getAsJsonArray();
+    }
+
+    // parse json array string -> List<String>
+    public static List<String> parseStringList(String json) {
+        JsonArray array = parseArray(json);
+        List<String> values = new ArrayList<>();
+        for (JsonElement element : array) {
+            values.add(element.getAsString());
+        }
+        return values;
+    }
+}

--- a/src/main/java/uk/ac/comm2020/util/RequestUtil.java
+++ b/src/main/java/uk/ac/comm2020/util/RequestUtil.java
@@ -1,0 +1,51 @@
+package uk.ac.comm2020.util;
+
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+// Request helper.
+// Read body, and parse query params.
+public final class RequestUtil {
+    // no new RequestUtil()
+    private RequestUtil() {
+    }
+
+    // Read request body as utf-8 string.
+    public static String readBody(HttpExchange exchange) throws IOException {
+        return new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    // Parse query part in URL, like ?a=1&b=2
+    public static Map<String, String> parseQuery(URI uri) {
+        String query = uri.getRawQuery();
+        Map<String, String> params = new HashMap<>();
+
+        // no query -> empty map
+        if (query == null || query.isBlank()) {
+            return params;
+        }
+
+        // split by &
+        String[] pairs = query.split("&");
+        for (String pair : pairs) {
+            int idx = pair.indexOf('=');
+            if (idx <= 0) {
+                continue;
+            }
+
+            // decode key/value
+            String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
+            String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
+
+            params.put(key, value);
+        }
+
+        return params;
+    }
+}

--- a/src/main/java/uk/ac/comm2020/util/ResponseUtil.java
+++ b/src/main/java/uk/ac/comm2020/util/ResponseUtil.java
@@ -1,0 +1,56 @@
+package uk.ac.comm2020.util;
+
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+// Response helper.
+// Build success/error body, and send json out.
+public final class ResponseUtil {
+    
+    private ResponseUtil() {
+    }
+
+    // success wrapper: { success: true, data: ... }
+    public static Map<String, Object> success(Object data) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("success", true);
+        body.put("data", data);
+        return body;
+    }
+
+    // error wrapper: { success: false, error: { code, message, details? } }
+    public static Map<String, Object> error(String code, String message, Map<String, Object> details) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("success", false);
+
+        Map<String, Object> error = new HashMap<>();
+        error.put("code", code);
+        error.put("message", message);
+
+        // details is optional
+        if (details != null) {
+            error.put("details", details);
+        }
+
+        body.put("error", error);
+        return body;
+    }
+
+    // Send json to client.
+    // Set content-type, write bytes, then close output.
+    public static void sendJson(HttpExchange exchange, int status, Object body) throws IOException {
+        byte[] bytes = JsonUtil.toJson(body).getBytes(StandardCharsets.UTF_8);
+
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+
+        try (OutputStream output = exchange.getResponseBody()) {
+            output.write(bytes);
+        }
+    }
+}

--- a/src/main/resources/static/authoring.html
+++ b/src/main/resources/static/authoring.html
@@ -1,0 +1,408 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Passport Authoring</title>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      body {
+        margin: 0;
+        font-family: Arial, sans-serif;
+        background: #f4f7fb;
+        color: #1f2937;
+      }
+      .container {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 16px;
+      }
+      header {
+        padding: 12px 0;
+        background: #eef2ff;
+        border-radius: 12px;
+        margin-bottom: 16px;
+        padding: 16px;
+        border: 1px solid rgba(99, 102, 241, 0.15);
+      }
+      h1 {
+        font-size: 1.4rem;
+        margin: 0 0 8px;
+      }
+      .card {
+        background: #ffffff;
+        border: 1px solid rgba(99, 102, 241, 0.12);
+        border-radius: 12px;
+        padding: 16px;
+        margin-bottom: 16px;
+        box-shadow: 0 12px 32px rgba(148, 163, 184, 0.2);
+      }
+      label {
+        display: block;
+        font-weight: 600;
+        margin: 10px 0 6px;
+      }
+      input, select, button, textarea {
+        width: 100%;
+        padding: 10px;
+        border-radius: 6px;
+        border: 1px solid rgba(148, 163, 184, 0.6);
+        box-sizing: border-box;
+        font-size: 0.95rem;
+        background: #ffffff;
+        color: #1f2937;
+      }
+      button {
+        background: #7da4ff;
+        border: none;
+        color: #fff;
+        font-weight: 600;
+        cursor: pointer;
+        box-shadow: 0 8px 20px rgba(99, 102, 241, 0.2);
+      }
+      button.secondary {
+        background: #94a3b8;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 12px;
+      }
+      .message {
+        margin-top: 12px;
+        padding: 10px;
+        border-radius: 6px;
+        background: #e8f0ff;
+        color: #1e3a8a;
+        display: none;
+      }
+      .message.error {
+        background: #ffe4e7;
+        color: #9f1239;
+      }
+      .status-line {
+        font-size: 0.95rem;
+        color: #64748b;
+        margin-top: 6px;
+      }
+      .input-error {
+        border-color: #fb7185;
+        background: #fff1f2;
+      }
+      .field-group-title {
+        margin: 10px 0 0;
+        font-weight: 700;
+        color: #475569;
+      }
+      @media (max-width: 600px) {
+        h1 {
+          font-size: 1.2rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>Passport Authoring</h1>
+        // show small status text to user
+        <div class="status-line" id="statusLine">Ready.</div>
+      </header>
+
+      <section class="card">
+        <div class="row">
+          <div>
+            <label for="categoryInput">Category</label>
+            <input id="categoryInput" type="text" value="Battery" placeholder="Battery">
+          </div>
+          <div>
+            <label>&nbsp;</label>
+            // load template + product list
+            <button id="loadBtn">Load Templates & Products</button>
+          </div>
+        </div>
+        <div class="row">
+          <div>
+            <label for="templateSelect">Template</label>
+            <select id="templateSelect"></select>
+          </div>
+          <div>
+            <label for="productSelect">Product</label>
+            <select id="productSelect"></select>
+          </div>
+        </div>
+        <div class="row">
+          <div>
+            <label>&nbsp;</label>
+            // create a draft passport in backend
+            <button id="createPassportBtn" class="secondary">Create Draft Passport</button>
+          </div>
+        </div>
+        // message box for load/create errors
+        <div class="message" id="loadMessage"></div>
+      </section>
+
+      <section class="card" id="formCard" style="display:none;">
+        <div class="field-group-title">Required Fields</div>
+        <div id="requiredFields"></div>
+        <div class="field-group-title">Optional Fields</div>
+        <div id="optionalFields"></div>
+        <div class="row">
+          <div>
+            <label>&nbsp;</label>
+            // save form data to backend
+            <button id="saveBtn">Save Fields</button>
+          </div>
+        </div>
+        // message box for save result
+        <div class="message" id="saveMessage"></div>
+      </section>
+    </div>
+
+    <script>
+      // cache dom nodes, so later use easy
+      const categoryInput = document.getElementById("categoryInput");
+      const loadBtn = document.getElementById("loadBtn");
+      const templateSelect = document.getElementById("templateSelect");
+      const productSelect = document.getElementById("productSelect");
+      const createPassportBtn = document.getElementById("createPassportBtn");
+      const statusLine = document.getElementById("statusLine");
+      const loadMessage = document.getElementById("loadMessage");
+      const formCard = document.getElementById("formCard");
+      const requiredFieldsContainer = document.getElementById("requiredFields");
+      const optionalFieldsContainer = document.getElementById("optionalFields");
+      const saveBtn = document.getElementById("saveBtn");
+      const saveMessage = document.getElementById("saveMessage");
+
+      // keep some state here
+      let templatesById = {};
+      let currentPassportId = null;
+      let currentTemplate = null;
+      let fieldInputs = {};
+
+      // load templates + products by category
+      loadBtn.addEventListener("click", () => {
+        loadMessage.style.display = "none";
+        statusLine.textContent = "Loading templates and products...";
+
+        const category = categoryInput.value.trim();
+        if (!category) {
+          showMessage(loadMessage, "Please enter a category.", true);
+          statusLine.textContent = "Category missing.";
+          return;
+        }
+
+        // call two apis at same time
+        Promise.all([
+          fetch(`/api/templates?category=${encodeURIComponent(category)}`),
+          fetch(`/api/products?category=${encodeURIComponent(category)}`)
+        ])
+          .then(async ([templatesRes, productsRes]) => {
+            const templatesJson = await templatesRes.json();
+            const productsJson = await productsRes.json();
+
+            // backend use { success: true/false }
+            if (!templatesJson.success) {
+              throw new Error(templatesJson.error?.message || "Failed to load templates");
+            }
+            if (!productsJson.success) {
+              throw new Error(productsJson.error?.message || "Failed to load products");
+            }
+
+            updateTemplates(templatesJson.data.templates || []);
+            updateProducts(productsJson.data.products || []);
+
+            showMessage(loadMessage, "Loaded templates and products.", false);
+            statusLine.textContent = "Loaded. Select product and template.";
+          })
+          .catch((err) => {
+            showMessage(loadMessage, err.message, true);
+            statusLine.textContent = "Failed to load.";
+          });
+      });
+
+      // create draft passport
+      createPassportBtn.addEventListener("click", () => {
+        saveMessage.style.display = "none";
+
+        const productId = productSelect.value;
+        const templateId = templateSelect.value;
+        if (!productId || !templateId) {
+          showMessage(loadMessage, "Select both product and template.", true);
+          return;
+        }
+
+        statusLine.textContent = "Creating draft passport...";
+
+        fetch("/api/passports", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            productId: Number(productId),
+            templateId: Number(templateId)
+          })
+        })
+          .then((res) => res.json())
+          .then((json) => {
+            if (!json.success) {
+              throw new Error(json.error?.message || "Failed to create passport");
+            }
+
+            // keep id + template in memory
+            currentPassportId = json.data.passportId;
+            currentTemplate = templatesById[templateId];
+
+            statusLine.textContent = `Draft passport #${currentPassportId} created.`;
+
+            // show form for this template
+            renderForm(currentTemplate);
+          })
+          .catch((err) => {
+            showMessage(loadMessage, err.message, true);
+            statusLine.textContent = "Failed to create passport.";
+          });
+      });
+
+      // save fields to backend
+      saveBtn.addEventListener("click", () => {
+        if (!currentPassportId) {
+          showMessage(saveMessage, "Create a passport first.", true);
+          return;
+        }
+
+        clearFieldErrors();
+
+        const fields = collectFields();
+        statusLine.textContent = "Saving fields...";
+
+        fetch(`/api/passports/${currentPassportId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ fields })
+        })
+          .then((res) => res.json())
+          .then((json) => {
+            if (!json.success) {
+              // show missing keys, and mark inputs red
+              const missing = json.error?.details?.missingFields || [];
+              if (missing.length) {
+                missing.forEach((key) => markFieldError(key));
+                showMessage(saveMessage, `Missing required fields: ${missing.join(", ")}`, true);
+              } else {
+                showMessage(saveMessage, json.error?.message || "Save failed.", true);
+              }
+              statusLine.textContent = "Validation failed.";
+              return;
+            }
+
+            showMessage(saveMessage, "Saved successfully.", false);
+            statusLine.textContent = "Saved.";
+          })
+          .catch((err) => {
+            showMessage(saveMessage, err.message, true);
+            statusLine.textContent = "Save failed.";
+          });
+      });
+
+      // fill template dropdown, also build a id->template map
+      function updateTemplates(templates) {
+        templatesById = {};
+        templateSelect.innerHTML = "";
+
+        templates.forEach((template) => {
+          templatesById[String(template.templateId)] = template;
+
+          const option = document.createElement("option");
+          option.value = template.templateId;
+          option.textContent = `#${template.templateId} (${template.category})`;
+          templateSelect.appendChild(option);
+        });
+      }
+
+      // fill product dropdown
+      function updateProducts(products) {
+        productSelect.innerHTML = "";
+
+        products.forEach((product) => {
+          const option = document.createElement("option");
+          option.value = product.productId;
+          option.textContent = `#${product.productId} ${product.name}`;
+          productSelect.appendChild(option);
+        });
+      }
+
+      // show input form by template fields
+      function renderForm(template) {
+        if (!template) {
+          return;
+        }
+
+        formCard.style.display = "block";
+        requiredFieldsContainer.innerHTML = "";
+        optionalFieldsContainer.innerHTML = "";
+        fieldInputs = {};
+
+        buildFieldGroup(template.requiredFields || [], requiredFieldsContainer, true);
+        buildFieldGroup(template.optionalFields || [], optionalFieldsContainer, false);
+      }
+
+      // build inputs for one group
+      function buildFieldGroup(fields, container, required) {
+        fields.forEach((fieldKey) => {
+          const wrapper = document.createElement("div");
+
+          const label = document.createElement("label");
+          label.textContent = required ? `${fieldKey} (required)` : fieldKey;
+
+          const input = document.createElement("input");
+          input.type = "text";
+          input.placeholder = fieldKey;
+          input.dataset.fieldKey = fieldKey;
+
+          wrapper.appendChild(label);
+          wrapper.appendChild(input);
+          container.appendChild(wrapper);
+
+          // keep ref, so later we can read / mark error
+          fieldInputs[fieldKey] = input;
+        });
+      }
+
+      // read values from inputs, make a fields object
+      function collectFields() {
+        const fields = {};
+        Object.keys(fieldInputs).forEach((key) => {
+          const value = fieldInputs[key].value.trim();
+          if (value) {
+            fields[key] = value;
+          }
+        });
+        return fields;
+      }
+
+      // clear red border on inputs
+      function clearFieldErrors() {
+        Object.values(fieldInputs).forEach((input) => {
+          input.classList.remove("input-error");
+        });
+      }
+
+      // mark one input as error
+      function markFieldError(fieldKey) {
+        const input = fieldInputs[fieldKey];
+        if (input) {
+          input.classList.add("input-error");
+        }
+      }
+
+      // show message box, error or normal
+      function showMessage(element, message, isError) {
+        element.textContent = message;
+        element.classList.toggle("error", isError);
+        element.style.display = "block";
+      }
+    </script>
+  </body>
+</html>

--- a/src/main/resources/static/consumer.html
+++ b/src/main/resources/static/consumer.html
@@ -1,0 +1,319 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Passport Consumer</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: Arial, sans-serif;
+        background: #f4f7fb;
+        color: #1f2937;
+      }
+      .container {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 16px;
+      }
+      h1 {
+        font-size: 1.4rem;
+        margin: 0 0 8px;
+      }
+      .card {
+        background: #ffffff;
+        border: 1px solid rgba(99, 102, 241, 0.12);
+        border-radius: 12px;
+        padding: 16px;
+        margin-bottom: 16px;
+        box-shadow: 0 12px 32px rgba(148, 163, 184, 0.2);
+      }
+      label {
+        display: block;
+        font-weight: 600;
+        margin: 10px 0 6px;
+      }
+      input, button {
+        width: 100%;
+        padding: 10px;
+        border-radius: 6px;
+        border: 1px solid rgba(148, 163, 184, 0.6);
+        box-sizing: border-box;
+        font-size: 0.95rem;
+        background: #ffffff;
+        color: #1f2937;
+      }
+      button {
+        background: #7da4ff;
+        border: none;
+        color: #fff;
+        font-weight: 600;
+        cursor: pointer;
+        box-shadow: 0 8px 20px rgba(99, 102, 241, 0.2);
+      }
+      .row {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 12px;
+      }
+      .message {
+        margin-top: 12px;
+        padding: 10px;
+        border-radius: 6px;
+        background: #ffe4e7;
+        color: #9f1239;
+        display: none;
+      }
+      .section-title {
+        margin: 6px 0 10px;
+        font-weight: 700;
+        color: #475569;
+      }
+      .field-list {
+        display: grid;
+        gap: 6px;
+      }
+      .field-item {
+        padding: 8px;
+        border-radius: 6px;
+        background: #f1f5f9;
+      }
+      .summary-grid {
+        display: grid;
+        gap: 8px;
+      }
+      .summary-item strong {
+        display: inline-block;
+        min-width: 140px;
+      }
+      @media (max-width: 600px) {
+        h1 {
+          font-size: 1.2rem;
+        }
+        .summary-item strong {
+          min-width: 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Passport Consumer View</h1>
+
+      <section class="card">
+        <div class="row">
+          <div>
+            <label for="passportIdInput">Passport ID</label>
+            <input id="passportIdInput" type="number" min="1" placeholder="e.g. 1">
+          </div>
+        </div>
+        <div class="row">
+          <div>
+            <label>&nbsp;</label>
+            // click to load passport by id
+            <button id="loadBtn">Load Passport</button>
+          </div>
+        </div>
+        // show error message here
+        <div class="message" id="loadMessage"></div>
+      </section>
+
+      <section class="card" id="summaryCard" style="display:none;">
+        <div class="section-title">Summary</div>
+        // summary key-value list
+        <div class="summary-grid" id="summaryGrid"></div>
+      </section>
+
+      <section class="card" id="detailsCard" style="display:none;">
+        <div class="section-title">Required Fields</div>
+        <div class="field-list" id="requiredList"></div>
+        <div class="section-title" style="margin-top:14px;">Optional Fields</div>
+        <div class="field-list" id="optionalList"></div>
+        <div class="section-title" style="margin-top:14px;">Other Fields</div>
+        <div class="field-list" id="otherList"></div>
+      </section>
+    </div>
+
+    <script>
+      // cache dom nodes
+      const passportIdInput = document.getElementById("passportIdInput");
+      const loadBtn = document.getElementById("loadBtn");
+      const loadMessage = document.getElementById("loadMessage");
+      const summaryCard = document.getElementById("summaryCard");
+      const detailsCard = document.getElementById("detailsCard");
+      const summaryGrid = document.getElementById("summaryGrid");
+      const requiredList = document.getElementById("requiredList");
+      const optionalList = document.getElementById("optionalList");
+      const otherList = document.getElementById("otherList");
+
+      // support url like ?id=123
+      const params = new URLSearchParams(window.location.search);
+      const initialId = params.get("id");
+
+      // if url has id, fill it
+      if (initialId) {
+        passportIdInput.value = initialId;
+      }
+
+      // auto load when id exists
+      if (initialId) {
+        loadPassport();
+      }
+
+      loadBtn.addEventListener("click", loadPassport);
+
+      // load passport + template, then show ui
+      function loadPassport() {
+        const passportId = passportIdInput.value.trim();
+        if (!passportId) {
+          showMessage("Please enter a passport id.");
+          return;
+        }
+
+        // clear old message
+        showMessage("");
+
+        fetch(`/api/passports/${passportId}`)
+          .then((res) => res.json())
+          .then(async (json) => {
+            if (!json.success) {
+              throw new Error(json.error?.message || "Failed to load passport");
+            }
+
+            const passport = json.data;
+
+            // template is for required/optional groups
+            const template = await fetchTemplateById(passport.templateId);
+
+            renderSummary(passport);
+            renderDetails(passport.fields || {}, template);
+          })
+          .catch((err) => {
+            showMessage(err.message);
+            summaryCard.style.display = "none";
+            detailsCard.style.display = "none";
+          });
+      }
+
+      // load template by id, fail then return null
+      async function fetchTemplateById(templateId) {
+        try {
+          const res = await fetch(`/api/templates/${templateId}`);
+          const json = await res.json();
+          if (!json.success) {
+            return null;
+          }
+          return json.data;
+        } catch {
+          return null;
+        }
+      }
+
+      // show summary info on top
+      function renderSummary(passport) {
+        summaryGrid.innerHTML = "";
+
+        // basic info
+        const summaryItems = [
+          ["Passport ID", passport.passportId],
+          ["Product ID", passport.productId],
+          ["Template ID", passport.templateId],
+          ["Status", passport.status],
+          ["Completeness", passport.completenessScore],
+          ["Confidence", passport.confidenceScore]
+        ];
+
+        // show some common fields if they exist
+        const keyFields = ["name", "brand", "origin", "chemistry"];
+        keyFields.forEach((key) => {
+          if (passport.fields && passport.fields[key] !== undefined) {
+            summaryItems.push([key, passport.fields[key]]);
+          }
+        });
+
+        // render items
+        summaryItems.forEach(([label, value]) => {
+          const item = document.createElement("div");
+          item.className = "summary-item";
+          item.innerHTML = `<strong>${label}:</strong> ${formatValue(value)}`;
+          summaryGrid.appendChild(item);
+        });
+
+        summaryCard.style.display = "block";
+      }
+
+      // split fields into required / optional / other
+      function renderDetails(fields, template) {
+        requiredList.innerHTML = "";
+        optionalList.innerHTML = "";
+        otherList.innerHTML = "";
+
+        const requiredFields = template?.requiredFields || [];
+        const optionalFields = template?.optionalFields || [];
+        const usedKeys = new Set();
+
+        requiredFields.forEach((key) => {
+          usedKeys.add(key);
+          requiredList.appendChild(makeFieldItem(key, fields[key]));
+        });
+
+        optionalFields.forEach((key) => {
+          usedKeys.add(key);
+          optionalList.appendChild(makeFieldItem(key, fields[key]));
+        });
+
+        // any key not in template -> put to other
+        Object.keys(fields || {}).forEach((key) => {
+          if (!usedKeys.has(key)) {
+            otherList.appendChild(makeFieldItem(key, fields[key]));
+          }
+        });
+
+        // if empty, show (none)
+        if (!requiredList.children.length) {
+          requiredList.appendChild(makeFieldItem("(none)", ""));
+        }
+        if (!optionalList.children.length) {
+          optionalList.appendChild(makeFieldItem("(none)", ""));
+        }
+        if (!otherList.children.length) {
+          otherList.appendChild(makeFieldItem("(none)", ""));
+        }
+
+        detailsCard.style.display = "block";
+      }
+
+      // make one "key: value" row
+      function makeFieldItem(key, value) {
+        const item = document.createElement("div");
+        item.className = "field-item";
+
+        const displayValue = value === undefined ? "—" : formatValue(value);
+        item.textContent = `${key}: ${displayValue}`;
+
+        return item;
+      }
+
+      // simple value to string
+      function formatValue(value) {
+        if (value === null || value === undefined) {
+          return "";
+        }
+        if (typeof value === "object") {
+          return JSON.stringify(value);
+        }
+        return String(value);
+      }
+
+      // show error message box
+      function showMessage(message) {
+        if (!message) {
+          loadMessage.style.display = "none";
+          return;
+        }
+        loadMessage.textContent = message;
+        loadMessage.style.display = "block";
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What does this PR change?
- Implements Module B (CW1) minimal vertical slice using NoFramework `HttpServer` + JDBC + Gson
- Adds API endpoints (wrapped responses per `docs/api-contract.md`):
  - GET `/api/templates?category=...`
  - GET `/api/products?category=...`
  - POST `/api/passports` (create DRAFT with `fields={}`)
  - PUT `/api/passports/{passportId}` (update fields + required-field validation + completenessScore; confidenceScore=0)
  - GET `/api/passports/{passportId}` (passport + fields + scores)
  - GET `/api/templates/{templateId}` (read-only helper for consumer grouping)
- Adds static pages served by backend (avoid `file://` CORS):
  - `/authoring.html` (template-driven form; highlights `details.missingFields` on save)
  - `/consumer.html` (summary + details; supports `?id=...`)

## Related Issue
- Closes # (N/A)

## How to test
- [x] Local run (command):
  - Configure DB env vars (either `.env` or IDE Run Config):
    - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
  - Run: `uk.ac.comm2020.App` with program args: `server`
  - DB init/seed: run `db/migrations/001_init.sql` then `db/seed/seed.sql` (see README)
- [ ] Automated tests (command):
  - `mvn test` (not run locally; CI should verify)
- [x] Manual steps (if any):
  1. Open `http://localhost:8080/authoring.html`
  2. Enter category `Battery` → Load (fetch templates/products)
  3. Select product + template → Create passport (DRAFT)
  4. Click Save with missing required fields → expect `success=false` + `details.missingFields` and UI highlights
  5. Fill required fields → Save success; completenessScore updates
  6. Open `http://localhost:8080/consumer.html?id=<passportId>` to view summary/details

## Contract impact (tick if yes)
- [ ] DB schema change (migration added)
- [ ] API payload/endpoint change (api-contract updated)
- [ ] Seed data updated

## Checklist
- [x] No secrets committed (`.env` not committed)
- [x] Code builds successfully (runs in IntelliJ with DB configured)
- [ ] Tests updated/added where applicable (N/A for CW1 minimal slice)
- [x] Docs updated where applicable (README demo steps + curl examples)
